### PR TITLE
Add ownership checks to hololib parent functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -1224,12 +1224,12 @@ end
 
 e2function void holoParent(index, entity ent)
 	if not IsValid(ent) then return end
-	local Holo = CheckIndex(self, index)
-	if not Holo then return end
-
 	if not E2Lib.isOwner(self, ent) then
 		return self:throw("You do not have permission to parent to this entity", nil)
 	end
+
+	local Holo = CheckIndex(self, index)
+	if not Holo then return end
 
 	if not Check_Parents(Holo.ent, ent) then return end
 
@@ -1238,12 +1238,12 @@ end
 
 e2function void holoParentAttachment(index, entity ent, string attachmentName)
 	if not IsValid(ent) then return end
-	local Holo = CheckIndex(self, index)
-	if not Holo then return end
-
 	if not E2Lib.isOwner(self, ent) then
 		return self:throw("You do not have permission to parent to this entity", nil)
 	end
+
+	local Holo = CheckIndex(self, index)
+	if not Holo then return end
 
 	Parent_Hologram(Holo, ent, attachmentName)
 end

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -1227,6 +1227,10 @@ e2function void holoParent(index, entity ent)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
 
+	if not E2Lib.isOwner(self, ent) then
+		return self:throw("You do not have permission to parent to this entity", nil)
+	end
+
 	if not Check_Parents(Holo.ent, ent) then return end
 
 	Parent_Hologram(Holo, ent, nil)
@@ -1236,6 +1240,10 @@ e2function void holoParentAttachment(index, entity ent, string attachmentName)
 	if not IsValid(ent) then return end
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
+
+	if not E2Lib.isOwner(self, ent) then
+		return self:throw("You do not have permission to parent to this entity", nil)
+	end
 
 	Parent_Hologram(Holo, ent, attachmentName)
 end


### PR DESCRIPTION
<!--
PR pre-flight checks:
- Have you tested your changes in-game, and using srcds? (either locally hosted or remote)
- Have you done a brief self-review of your changes to check if you've missed anything?
- If working on an issue with defined scope and/or acceptance criteria, have you checked that you've hit everything?
  - If you intentionally haven't followed the issue's requirements, please describe which requirements haven't been hit and why
-->

## Issue

User complaints

## Changes

- Adds `E2Lib.isOwner` checks to the `holoParent` and `holoParentAttachment` functions

## Impact

This prevents parenting entities to other entities you do not own

## Testing

Already passed QA on the original PR to upstream Wire and actively used on the UK server

## Helpful Links

[Discord](https://discord.tasevers.com)
