### PR TITLE
Replace debug.getregistry with FindMetaTable

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -902,9 +902,6 @@ for funcname, _ in pairs(makeglobal) do
 	_G[funcname] = E2Lib[funcname]
 end
 
-local PLAYER_METATABLE = FindMetaTable("Player")
-local ENTITY_METATABLE = FindMetaTable("Entity")
-
 hook.Add("InitPostEntity", "e2lib", function()
 -- If changed, put them into the global scope again.
 	registerCallback("e2lib_replace_function", function(funcname, func, oldfunc)
@@ -918,7 +915,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 
 	-- check for a CPPI compliant plugin
 	if SERVER and CPPI then
-		if PLAYER_METATABLE.CPPIGetFriends then
+		if FindMetaTable("Player").CPPIGetFriends then
 			E2Lib.replace_function("isFriend", function(owner, player)
 				if owner == nil then return false end
 				if owner == player then return true end
@@ -937,7 +934,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 			end)
 		end
 
-		if ENTITY_METATABLE.CPPIGetOwner then
+		if FindMetaTable("Entity").CPPIGetOwner then
 			local _getOwner = E2Lib.getOwner
 			E2Lib.replace_function("getOwner", function(self, entity)
 				if not IsValid(entity) then return end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -902,6 +902,9 @@ for funcname, _ in pairs(makeglobal) do
 	_G[funcname] = E2Lib[funcname]
 end
 
+local PLAYER_METATABLE = FindMetaTable("Player")
+local ENTITY_METATABLE = FindMetaTable("Entity")
+
 hook.Add("InitPostEntity", "e2lib", function()
 -- If changed, put them into the global scope again.
 	registerCallback("e2lib_replace_function", function(funcname, func, oldfunc)
@@ -915,7 +918,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 
 	-- check for a CPPI compliant plugin
 	if SERVER and CPPI then
-		if debug.getregistry().Player.CPPIGetFriends then
+		if PLAYER_METATABLE.CPPIGetFriends then
 			E2Lib.replace_function("isFriend", function(owner, player)
 				if owner == nil then return false end
 				if owner == player then return true end
@@ -934,7 +937,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 			end)
 		end
 
-		if debug.getregistry().Entity.CPPIGetOwner then
+		if ENTITY_METATABLE.CPPIGetOwner then
 			local _getOwner = E2Lib.getOwner
 			E2Lib.replace_function("getOwner", function(self, entity)
 				if not IsValid(entity) then return end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -509,11 +509,9 @@ end
 
 --------------------------------------------------------------------------------
 
-local PLAYER_METATABLE = FindMetaTable("Player")
-
 __e2setcost(2)
 
-if CPPI and PLAYER_METATABLE.CPPIGetFriends then
+if CPPI and FindMetaTable("Player").CPPIGetFriends then
 
 	local function Trusts(ply, whom)
 		if ply == whom then return true end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -509,9 +509,11 @@ end
 
 --------------------------------------------------------------------------------
 
+local PLAYER_METATABLE = FindMetaTable("Player")
+
 __e2setcost(2)
 
-if CPPI and debug.getregistry().Player.CPPIGetFriends then
+if CPPI and PLAYER_METATABLE.CPPIGetFriends then
 
 	local function Trusts(ply, whom)
 		if ply == whom then return true end


### PR DESCRIPTION
# Changes

Replaces all instances of `debug.getregistry` with `FindMetaTable`

# Impact

Allows Wiremod to work on the latest version of GMod, which unblocks updating the server

# Testing

Smoke test to make sure `player:isFriend`, `entity:getOwner` and CPPI-specific functions like `entity:friends` all work when prop protection is installed