### PR TITLE
Bump changed files action version to v41

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get any changed files
         id: changed-files
-        uses: tj-actions/changed-files@v36
+        uses: tj-actions/changed-files@v41
         with:
           files: |
             **.lua


### PR DESCRIPTION
# Changes

Updates the changed-files action in `lua.yml` to version 41

# Impact

Fixes a code injection exploit in PR names

# Testing

n/a